### PR TITLE
The Checklist Status column is too wide

### DIFF
--- a/assets/css/ppc-css.css
+++ b/assets/css/ppc-css.css
@@ -557,3 +557,7 @@ input.ppc_checkboxes{
 td.column-ppc_checklist{
   font-style: italic;
 }
+
+.column-ppc_checklist{
+  width: 12%;
+}


### PR DESCRIPTION
Add "width: 12%;" to the class .column-ppc_checklist

See screenshot:
![2020-05-08_171801](https://user-images.githubusercontent.com/7474702/81420284-0f665f80-9150-11ea-83ab-db70d58a2dfc.png)
